### PR TITLE
Fix length checking of repeated_char for non-English languages

### DIFF
--- a/src/funcs.rs
+++ b/src/funcs.rs
@@ -229,7 +229,7 @@ fn attachments_to_format(attachments: &[serenity::Attachment]) -> Option<&'stati
 fn remove_repeated_chars(content: &str, limit: usize) -> String {
     content.chars().group_by(|&c| c).into_iter().map(|(key, group)| {
         let group: String = group.collect();
-        if group.len() > limit {
+        if group.chars().count() > limit {
             key.to_string().repeat(limit)
         } else {
             group


### PR DESCRIPTION
Hello, I'm Korean. I usually use the TTS Bot with my friends usefully.
We really appreciate for developers.

But we have found that _repeated_chars_ doesn't work as we intended for Korean and Japanese.


## What is the problem?

_repeated_characters_ is set as below 
```
/set repeated_characters 5
```

Let's assume that the message to be spoken is
```
ここんんにに
```

It will be filtered by _**remove_repeated_chars()**_,
but supposed to be same as before.

What we expect :
```
ここんんにに (intact)
```


What actually has been spoken :
```
こここここんんんんんににににに
```

## Why it has happened?

#### The length of "ここ" is not 2, but 6 ( 3 for each )
Rust seems to handle Unicode strings as bytes length

### Proof of work
```
fn main() {
	let japanese: String = "ここ".into();
	println!("{:?}", japanese.len());
	println!("{:?}", japanese.as_bytes());

}
```

### Results
```
6
[227, 129, 147, 227, 129, 147]
```

## Solution
String.chars().count() retrieves precise length for any languages.
```
fn main() {
        let japanese: String = "ここ".into();
	println!("{:?}", japanese.chars().count());
}
```
Result
```
2
```

I hope this issue will be fixed.