### PR TITLE
Fix branch name of num-format dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ generic-array = "0.14"
 
 [dependencies.num-format]
 git = "https://github.com/niklasha/num-format"
-branch = "master"
+branch = "main"
 
 [dependencies.symphonia]
 git = "https://github.com/FelixMcFelix/Symphonia"


### PR DESCRIPTION
The name of num-format "master" branch has been changed into "main",
which results in current cargo build fail.

https://github.com/niklasha/num-format


### Github Action fail log
https://github.com/Discord-TTS/Bot/actions/runs/3324687744/jobs/5496559659#step:5:392
```
> [builder 5/7] RUN mkdir src &&     echo "// dummy file" > src/lib.rs &&     cargo build --release &&     rm -r src:
#12 70.57 error: failed to get `num-format` as a dependency of package `discord_tts_bot v0.1.0 (/bot)`
#12 70.57 
#12 70.57 Caused by:
#12 70.57   failed to load source for dependency `num-format`
#12 70.57 
#12 70.57 Caused by:
#12 70.57   Unable to update https://github.com/niklasha/num-format?branch=master#6b06d755
#12 70.57 
#12 70.57 Caused by:
#12 70.57   object not found - no match for id (6b06d75568c18ee3ce6695f0[377](https://github.com/Discord-TTS/Bot/actions/runs/3324687744/jobs/5496559659#step:5:379)dbd961ed2ce79); class=Odb (9); code=NotFound (-3)
------
Dockerfile:10
--------------------
   9 |     COPY Cargo.toml Cargo.lock ./
  10 | >>> RUN mkdir src && \
  11 | >>>     echo "// dummy file" > src/lib.rs && \
  12 | >>>     cargo build --release && \
  13 | >>>     rm -r src
  14 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c mkdir src &&     echo \"// dummy file\" > src/lib.rs &&     cargo build --release &&     rm -r src" did not complete successfully: exit code: 101
Error: buildx failed with: ERROR: failed to solve: process "/bin/sh -c mkdir src &&     echo \"// dummy file\" > src/lib.rs &&     cargo build --release &&     rm -r src" did not complete successfully: exit code: 101
```