### PR TITLE
Save string allocation on prefix commands using non-default prefix

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -164,7 +164,9 @@ async fn main_(start_time: std::time::SystemTime) -> Result<()> {
         ),
         pre_command: analytics::pre_command,
         prefix_options: poise::PrefixFrameworkOptions {
-            dynamic_prefix: Some(|ctx| Box::pin(tts_commands::get_prefix(ctx))),
+            stripped_dynamic_prefix: Some(|ctx, message, _| {
+                Box::pin(tts_commands::try_strip_prefix(ctx, message))
+            }),
             ..poise::PrefixFrameworkOptions::default()
         },
         command_check: Some(|ctx| Box::pin(tts_commands::command_check(ctx))),

--- a/tts_commands/src/lib.rs
+++ b/tts_commands/src/lib.rs
@@ -9,7 +9,7 @@ use serenity::all::{self as serenity, Mentionable as _};
 use tts_core::{
     constants::PREMIUM_NEUTRAL_COLOUR,
     opt_ext::OptionTryUnwrap as _,
-    structs::{Command, Context, FailurePoint, PartialContext, Result},
+    structs::{Command, Context, Data, FailurePoint, Result},
     traits::PoiseContextExt,
 };
 
@@ -111,22 +111,26 @@ pub async fn premium_command_check(ctx: Context<'_>) -> Result<bool> {
     Ok(false)
 }
 
-pub async fn get_prefix(ctx: PartialContext<'_>) -> Result<Option<Cow<'static, str>>> {
-    let Some(guild_id) = ctx.guild_id else {
-        return Ok(Some(Cow::Borrowed("-")));
+pub async fn try_strip_prefix<'a>(
+    ctx: &serenity::Context,
+    message: &'a serenity::Message,
+) -> Result<Option<(&'a str, &'a str)>> {
+    let Some(guild_id) = message.guild_id else {
+        if message.content.strip_prefix("-").is_some() {
+            return Ok(Some(message.content.split_at("-".len())));
+        }
+        return Ok(None);
     };
 
-    let data = ctx.framework.user_data();
+    let data = ctx.data_ref::<Data>();
     let row = data.guilds_db.get(guild_id.into()).await?;
 
     let prefix = row.prefix.as_str();
-    let prefix = if prefix == "-" {
-        Cow::Borrowed("-")
-    } else {
-        Cow::Owned(String::from(prefix))
-    };
+    if message.content.strip_prefix(prefix).is_some() {
+        return Ok(Some(message.content.split_at(prefix.len())));
+    }
 
-    Ok(Some(prefix))
+    Ok(None)
 }
 
 #[cold]


### PR DESCRIPTION
begone `Cow::Owned(String::from(prefix))`